### PR TITLE
force date command to use China Standard Time zone

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -5,6 +5,7 @@ if [ -n "$1" ] && [ -n "$2" ]; then
     endpoint="https://api.nextday.im$pathAndQuery"
     name=$1
     secret=$2
+    TZ='Asia/Shanghai'
     date=$(date +'%Y-%m-%d %H:%M:%S')
     echo -n "$pathAndQuery&$name&$date&$secret" | md5sum | cut -d" " -f1 | { read hash; curl -H "X-ND-Date: $date" -H "Authorization: $name:$hash" $endpoint; }
 else

--- a/testMac.sh
+++ b/testMac.sh
@@ -7,6 +7,7 @@ if [ -n "$1" ] && [ -n "$2" ]; then
     endpoint="https://api.nextday.im$pathAndQuery"
     name=$1
     secret=$2
+    TZ='Asia/Shanghai'
     date=$(date +'%Y-%m-%d %H:%M:%S')
     hash=$(md5 -q -s "$pathAndQuery&$name&$date&$secret")
     curl --tlsv1.2 -H "X-ND-Date: $date" -H "Authorization: $name:$hash" $endpoint


### PR DESCRIPTION
The `test.sh/testMac.sh` scripts may encounter `Header 'X-ND-Date' or 'Date' expired` error when the user's time zone is not `China Standard Time`, so I set the `TZ` environment variable to `Asia/Shanghai` to make sure the `date` command use `China Standard Time`.